### PR TITLE
fix: move origin from container to options

### DIFF
--- a/src/main/java/de/adesso/softauthn/serialization/CredentialsDeserializer.java
+++ b/src/main/java/de/adesso/softauthn/serialization/CredentialsDeserializer.java
@@ -32,12 +32,6 @@ public class CredentialsDeserializer extends StdDeserializer<CredentialsContaine
     @Override
     public CredentialsContainer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
         JsonNode jsonNode = p.readValueAsTree();
-        final var scheme = jsonNode.get("origin.scheme").asText();
-        final var host = jsonNode.get("origin.host").asText();
-        final var port = jsonNode.has("origin.port") ? jsonNode.get("origin.port").asInt() : -1;
-        final var domain = jsonNode.has("origin.domain") ? jsonNode.get("origin.domain").asText() : null;
-
-        final var origin = new Origin(scheme, host, port, domain);
 
         final var authenticators = new ArrayList<Authenticator>();
         jsonNode.get("authenticators").elements().forEachRemaining(jsonAuthenticator -> {
@@ -127,7 +121,7 @@ public class CredentialsDeserializer extends StdDeserializer<CredentialsContaine
         });
 
 
-        final var result = new CredentialsContainer(origin, authenticators);
+        final var result = new CredentialsContainer(authenticators);
         return result;
     }
 }

--- a/src/main/java/de/adesso/softauthn/serialization/CredentialsSerializer.java
+++ b/src/main/java/de/adesso/softauthn/serialization/CredentialsSerializer.java
@@ -17,15 +17,6 @@ public class CredentialsSerializer extends StdSerializer<CredentialsContainer> {
     public void serialize(CredentialsContainer credentialsContainer, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
 
-        jsonGenerator.writeObjectField("origin.scheme", credentialsContainer.origin.getScheme());
-        jsonGenerator.writeObjectField("origin.host", credentialsContainer.origin.getHost());
-        if (credentialsContainer.origin.getPort().isPresent()) {
-            jsonGenerator.writeObjectField("origin.port", credentialsContainer.origin.getPort());
-        }
-        if (credentialsContainer.origin.getDomain().isPresent()) {
-            jsonGenerator.writeObjectField("origin.domain", credentialsContainer.origin.getDomain());
-        }
-
         jsonGenerator.writeArrayFieldStart("authenticators");
         for (final var authenticator : credentialsContainer.authenticators) {
             if (authenticator instanceof WebAuthnAuthenticator web) {

--- a/src/test/java/de/adesso/softauthn/CredentialsContainerTest.kt
+++ b/src/test/java/de/adesso/softauthn/CredentialsContainerTest.kt
@@ -14,7 +14,6 @@ import com.yubico.webauthn.data.ByteArray as YubiByteArray
 
 class CredentialsContainerTest {
     val authenticator = Authenticators.yubikey5Nfc().build()
-    val origin = URL("https://www.yubico.com").toOrigin()
     val options = PublicKeyCredentialCreationOptions
         .builder()
         .rp(
@@ -48,16 +47,17 @@ class CredentialsContainerTest {
 
     @Test
     fun createCredential() {
-        val container = CredentialsContainer(origin, listOf(authenticator))
+        val container = CredentialsContainer(listOf(authenticator))
         val credential = container.create(options)
 
         assertNotNull(credential)
         assertEquals(PublicKeyCredentialType.PUBLIC_KEY, credential.type)
+        assertEquals(options.rp.id, credential.response.clientData.origin)
     }
 
     @Test
     fun getCreatedCredential() {
-        val container = CredentialsContainer(origin, listOf(authenticator))
+        val container = CredentialsContainer(listOf(authenticator))
         val createdCredential = container.create(options)
 
         val credential = container.get(
@@ -81,7 +81,7 @@ class CredentialsContainerTest {
     @OptIn(ExperimentalStdlibApi::class)
     @Test
     fun storeAndRestoreContainer() {
-        val container = CredentialsContainer(origin, listOf(authenticator))
+        val container = CredentialsContainer(listOf(authenticator))
         container.create(options)
 
         val blob = container.serialize()
@@ -223,7 +223,7 @@ class CredentialsContainerTest {
     }
 
     fun create1010TestData() {
-        val container = CredentialsContainer(origin, listOf(authenticator))
+        val container = CredentialsContainer(listOf(authenticator))
 
         for (i in 0 until 10) {
             val alteredOption =
@@ -279,7 +279,7 @@ class CredentialsContainerTest {
     }
 
     fun create255TestData() {
-        val container = CredentialsContainer(origin, listOf(authenticator))
+        val container = CredentialsContainer(listOf(authenticator))
 
         for (i in 0 until 255) {
             val alteredOption =

--- a/src/test/resources/10-10-credentials.json
+++ b/src/test/resources/10-10-credentials.json
@@ -1,6 +1,4 @@
 {
-  "origin.scheme": "https",
-  "origin.host": "www.yubico.com",
   "authenticators": [
     {
       "type": "WebAuthnAuthenticator",

--- a/src/test/resources/255-credentials.json
+++ b/src/test/resources/255-credentials.json
@@ -1,6 +1,4 @@
 {
-  "origin.scheme": "https",
-  "origin.host": "www.yubico.com",
   "authenticators": [
     {
       "type": "WebAuthnAuthenticator",


### PR DESCRIPTION
For some reason the rp id was bound to the credential container, not the actual credential. My understanding is every credential contains it's own origin that is determined by its options, not the container / authenticator it resides in.